### PR TITLE
add fix for incorrect switch case indentation

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -122,7 +122,10 @@
     ],
     "indent": [
       "error",
-      4
+      4,
+      {
+        "SwitchCase": 1
+      }
     ],
     "keyword-spacing": [
       "error",


### PR DESCRIPTION
was:
```
switch (something) {
case: 
    doSomething();
    break;
}
```

now should be:
```
switch (something) {
    case: 
        doSomething();
        break;
}
```